### PR TITLE
Insert None at the last of attribs array

### DIFF
--- a/main.c
+++ b/main.c
@@ -83,7 +83,7 @@ int SetRenderWindow(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj
     XVisualInfo *__glVisinfo__ = (XVisualInfo *)NULL;
     int dummy;
     int attribs[] =
-        {GLX_USE_GL, GLX_RGBA, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 0};
+        {GLX_USE_GL, GLX_RGBA, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 0, None};
     GLXContext __glGLXContext__ = (void *)NULL;
 
     __glTkwin__ = Tk_NameToWindow(interp, Tcl_GetString (objv[1]), Tk_MainWindow(interp));


### PR DESCRIPTION
Hello, thank you for the nice example of OpenGL & Tcl/Tk.
I've fixed a minor bug. I would appreciate it if you could review.

# Issue
The following error was occurred in Ubuntu18.04 with NVIDIA Quadro P1000.
 
```bash
$ cd /path/to/opengl-tcltk
$ make -f Makefile_Linux # OK
$ ./main
__glVisinfo__ is NULL
```

# CHANGE LOG
- Insert None at the end of `attribs`.

# Why
The last attribute must be None, according to the specification of glXChooseVisual.
Please refer to https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glXChooseVisual.xml.

